### PR TITLE
Fix a bug causing mass crash

### DIFF
--- a/Systems/EntityNameTagRenderer.cs
+++ b/Systems/EntityNameTagRenderer.cs
@@ -49,7 +49,7 @@ namespace Vintagestory.GameContent
         internal NameTagRendererDelegate GetNameTagRenderer(Entity entity)
         {
             EntityPlayer eplr = entity as EntityPlayer;
-            var entitlements = eplr?.Player.Entitlements;
+            var entitlements = eplr?.Player?.Entitlements;
 
             if (entitlements?.Count > 0)
             {


### PR DESCRIPTION
### Issue:
Sometimes if a player crashes during loading into the world/cancels the loading, it will cause player entity to spawn without a player object attached to it. This will lead to every player in render radius crash with `NullReferenceException` while trying to render a name tag of this orphan player entity, leading to mass crashes (up to 30 people in densely populated areas).

### Steps to reproduce:
1. Launch a server
2. Join it with clients A and B
3. As client B, move in render distance of client A and log off
4. As client B, start joining the server but press "Cancel" right away/when you start receiving data
5. Repeat step 4 until you get the timing right(might take 10-20 attempts), causing client A to crash

### Example crash log:
```
Running on 64 bit Windows with 0 GB RAM 
Game Version: v1.18.6 (Stable)
23/08/2023 9:48:21 AM: Critical error occurred
Loaded Mods: game@1.18.6, creative@1.18.6, survival@1.18.6
System.NullReferenceException: Object reference not set to an instance of an object.
   at Vintagestory.GameContent.EntityNameTagRendererRegistry.GetNameTagRenderer(Entity entity) in VSEssentials\Systems\EntityNameTagRenderer.cs:line 51
   at Vintagestory.GameContent.EntityShapeRenderer.BeforeRender(Single dt) in VSEssentials\EntityRenderer\EntityShapeRenderer.cs:line 426
   at Vintagestory.Client.NoObf.SystemRenderEntities.OnBeforeRender(Single dt) in VintagestoryLib\Client\Systems\Render\RenderEntities.cs:line 68
   at Vintagestory.Client.NoObf.ClientEventManager.TriggerRenderStage(EnumRenderStage stage, Single dt) in VintagestoryLib\Client\Util\ClientEventManager.cs:line 199
   at Vintagestory.Client.NoObf.ClientMain.TriggerRenderStage(EnumRenderStage stage, Single dt) in VintagestoryLib\Client\ClientMain.cs:line 787
   at Vintagestory.Client.NoObf.ClientMain.MainRenderLoop(Single dt) in VintagestoryLib\Client\ClientMain.cs:line 829
   at Vintagestory.Client.NoObf.ClientMain.MainGameLoop(Single deltaTime) in VintagestoryLib\Client\ClientMain.cs:line 711
   at Vintagestory.Client.GuiScreenRunningGame.RenderToPrimary(Single dt) in VintagestoryLib\Client\MainMenu\Screens\GuiScreenRunningGame.cs:line 163
   at Vintagestory.Client.ScreenManager.Render(Single dt) in VintagestoryLib\Client\ScreenManager.cs:line 681
   at Vintagestory.Client.ScreenManager.OnNewFrame(Single dt) in VintagestoryLib\Client\ScreenManager.cs:line 625
   at Vintagestory.Client.NoObf.ClientPlatformWindows.window_RenderFrame(Object sender, FrameEventArgs e) in VintagestoryLib\Client\ClientPlatform\GameWindow.cs:line 119
   at System.EventHandler`1.Invoke(Object sender, TEventArgs e)
   at OpenTK.GameWindow.RaiseRenderFrame(Double elapsed, Double& timestamp) in C:\Users\User\Desktop\transfer\opentk\src\OpenTK\GameWindow.cs:line 476
   at OpenTK.GameWindow.DispatchRenderFrame() in C:\Users\User\Desktop\transfer\opentk\src\OpenTK\GameWindow.cs:line 452
   at OpenTK.GameWindow.Run(Double updates_per_second, Double frames_per_second) in C:\Users\User\Desktop\transfer\opentk\src\OpenTK\GameWindow.cs:line 375
   at Vintagestory.Client.ClientProgram.Start(ClientProgramArgs args, String[] rawArgs)
   at Vintagestory.ClientNative.CrashReporter.Start(ThreadStart start) in VintagestoryLib\Client\ClientPlatform\ClientNative\CrashReporter.cs:line 93
```

### Introduced solution:
The `IClientPlayer` object doesn't exist, so instead we just add additional null check inside `Vintagestory.GameContent.EntityNameTagRendererRegistry.GetNameTagRenderer` and use default name tag renderer.

### Was it tested?
Yes, the solution was tested on 1.18.6 (.net4), 1.18.6 (.net7) and 1.18.8. It solved the issue without introducing new ones.