### PR TITLE
Share waypoints with group

### DIFF
--- a/Systems/WorldMap/WaypointLayer/WaypointMapLayer.cs
+++ b/Systems/WorldMap/WaypointLayer/WaypointMapLayer.cs
@@ -425,6 +425,7 @@ namespace Vintagestory.GameContent
             {
                 Color = parsedColor.ToArgb() | (255 << 24),
                 OwningPlayerUid = player.PlayerUID,
+                OwningPlayerGroupId = groupId,
                 Position = pos,
                 Title = title,
                 Icon = icon,


### PR DESCRIPTION
This change allows players to share newly created waypoints with their group as long as the group tab is selected in the chatbox when creating the waypoint. The logic for this feature is mostly already there, it was just missing this one line to make it all work.

Proof of concept can be experienced with the [Sharable Waypoints](https://mods.vintagestory.at/sharablewaypoints) mod. Just install it on the server (no client side changes needed).