### PR TITLE
Make entities not perpetually stuck.

### DIFF
--- a/Entity/Pathfinding/Astar/WaypointsTraverser.cs
+++ b/Entity/Pathfinding/Astar/WaypointsTraverser.cs
@@ -312,7 +312,7 @@ namespace Vintagestory.Essentials
             if (distCheckAccum > 2)
             {
                 distCheckAccum = 0;
-                if (sqDistToTarget - lastDistToTarget < 0.1)
+                if (Math.Abs(sqDistToTarget - lastDistToTarget) < 0.1)
                 {
                     stuck = true;
                     stuckCounter += 30;


### PR DESCRIPTION
This value will always be less than 0 when approaching a waypoint. It needs to check the absolute value.