### PR TITLE
Mark multiply tree as dirty after modifying totalDaysCooldownUntil

### DIFF
--- a/Entity/Behavior/BehaviorMultiplyBase.cs
+++ b/Entity/Behavior/BehaviorMultiplyBase.cs
@@ -20,7 +20,7 @@ namespace Vintagestory.GameContent
         public double TotalDaysCooldownUntil
         {
             get { return multiplyTree.GetDouble("totalDaysCooldownUntil"); }
-            set { multiplyTree.SetDouble("totalDaysCooldownUntil", value); }
+            set { multiplyTree.SetDouble("totalDaysCooldownUntil", value); entity.WatchedAttributes.MarkPathDirty("multiply"); }
         }
 
         bool eatAnyway = false;


### PR DESCRIPTION
Missed one for #8.
Some line ending changes (\r\n -> \n) are also coming along for the ride.