### PR TITLE
Split harvestable drops into multiple stacks if above the stack limit

### DIFF
--- a/Entity/Behavior/BehaviorHarvestable.cs
+++ b/Entity/Behavior/BehaviorHarvestable.cs
@@ -426,6 +426,13 @@ namespace Vintagestory.GameContent
                     stack = slot.Itemstack;
                 }
 
+                while (stack.StackSize > stack.Collectible.MaxStackSize )
+                {
+                    ItemStack overflow = stack.GetEmptyClone();
+                    overflow.StackSize = stack.Collectible.MaxStackSize;
+                    stack.StackSize -= stack.Collectible.MaxStackSize;
+                    todrop.Add(overflow);
+                }
                 todrop.Add(stack);
                 if (dstack.LastDrop) break;
             }


### PR DESCRIPTION
Prevents harvestable creatures from giving items stacked beyond the stack size. For instance, if a drifter drops 2 temporal gears they would be in two separate slots with one gear each, not one stack of 2 gears.