### PR TITLE
If byType is not a json object, tell the user which key has the problem

### DIFF
--- a/Loading/RegistryObjectType.cs
+++ b/Loading/RegistryObjectType.cs
@@ -318,6 +318,10 @@ namespace Vintagestory.ServerMods.NoObf
                     {
                         string trueKey = entry.Key.Substring(0, entry.Key.Length - "byType".Length);
                         var jobj = entry.Value as JObject;
+                        if (jobj == null)
+                        {
+                            throw new FormatException("Invalid value at key: " + entry.Key);
+                        }
                         foreach (var byTypeProperty in jobj)
                         {
                             if (WildcardUtil.Match(byTypeProperty.Key, codePath))


### PR DESCRIPTION
If someone puts something silly like `idleSoundChanceByType: 0.05`, the error will now include the key where the problem happened, not just the file, making it easier to find and fix. Also it will be a file format exception rather than a null reference.

My text editor decided to make the file consistently use `\n` line endings instead of sometimes `\r\n`. This accounts for the other lines shown as changed, as can be seen with `git show | cat -v`.