### PR TITLE
Modify ignoreDaylightFlee test so daylight-sensitive drifters don't flee in storms

### DIFF
--- a/Entity/AI/Task/TasksImpl/AiTaskFleeEntity.cs
+++ b/Entity/AI/Task/TasksImpl/AiTaskFleeEntity.cs
@@ -70,10 +70,17 @@ namespace Vintagestory.GameContent
 
             // This code section controls drifter behavior - they retreat (flee slowly) from the player in the daytime, this is "switched off" below ground or at night, also switched off in temporal storms
             // Has to be checked every tick because the drifter attributes change during temporal storms  (grrr, this is a slow way to do it)
-            if (minDayLight > 0 && !entity.Attributes.GetBool("ignoreDaylightFlee", false))
+
+            // Do we use daylight levels to determine fleeing behaviour? If not skip all of this.
+            if (minDayLight > 0)
             {
+                // Are we currently in a temporal storm? If so then return false because we don't flee in storms.
+                if ( entity.Attributes.GetBool("ignoreDaylightFlee", false)) return false;
+
+                // Are we below sea level and set to ignore daylight levels underground? If so then return false because we don't flee underground.
                 if (ignoreDeepDayLight && entity.ServerPos.Y < world.SeaLevel - 2) return false;
 
+                //Is the light level too weak to affect us? If so then return false because the light is too dim to make us flee.
                 float sunlight = entity.World.BlockAccessor.GetLightLevel((int)entity.ServerPos.X, (int)entity.ServerPos.Y, (int)entity.ServerPos.Z, EnumLightLevelType.TimeOfDaySunLight) / (float)entity.World.SunBrightness;
                 if (sunlight < minDayLight) return false;
             }


### PR DESCRIPTION
I noticed that daylight sensitive drifters and shivers (the surface- and deep- variants) will exhibit fleeing behaviour in temporal storms if the temporal storm happens during the day.  According to the comment in the code of AiTaskFleeEntity this isn't supposed to happen. It simply states that drifters should ignore light levels during storms, without exception, so I assume this includes storms that happen during the day.  This patch changes the entity behaviour to reflect that.

I made a mod that uses the harmony transpiler to test this and my changes appear to work.  The mod description [here](https://mods.vintagestory.at/zippysfearlessfoes) has a longer explanation of my reasoning.

This is my first time submitting a PR on GitHub, so I hope I'm doing this right.