### PR TITLE
Change nest box suitability check and allow multiple chick codes (VSEssentials part)

### DIFF
--- a/Systems/POIRegistry.cs
+++ b/Systems/POIRegistry.cs
@@ -118,7 +118,7 @@ namespace Vintagestory.GameContent
 
     public interface IAnimalNest : IPointOfInterest
     {
-        bool IsSuitableFor(Entity entity);
+        bool IsSuitableFor(Entity entity, string[] nestTypes);
 
         /// <summary>
         /// Return true if occupied by an entity, which is not the same as the entity specified in the parameter
@@ -130,7 +130,7 @@ namespace Vintagestory.GameContent
         /// <summary>
         /// Returns true if an egg was successfully added
         /// </summary>
-        bool TryAddEgg(Entity entity, string chickCode, double incubationTime);
+        bool TryAddEgg(ItemStack egg);
 
         float DistanceWeighting { get; }
     }


### PR DESCRIPTION
Together with a PR to VSSurvivalMod (https://github.com/anegostudios/vssurvivalmod/pull/118), this does:

Modding API Feature: Species other than chickens are able to use the hen box if they use a matching nest type
Modding API Feature: AI task seekblockandlay now supports multiple chick types (such as male and female)
Modding API Tweak: IAnimalNest.TryAddEgg now takes an egg itemstack with chick info set in attributes