### PR TITLE
[POI Registry] Duplicate keys are created for the dictionary

### DIFF
--- a/Systems/POIRegistry.cs
+++ b/Systems/POIRegistry.cs
@@ -293,7 +293,11 @@ namespace Vintagestory.GameContent
             tmp.Set((int)poi.Position.X / chunksize, (int)poi.Position.Z / chunksize);
 
             PoisByChunkColumn.TryGetValue(tmp, out List<IPointOfInterest> pois);
-            if (pois != null) pois.Remove(poi);
+            if (pois != null)
+            {
+                pois.Remove(poi);
+                if (pois.Count == 0) PoisByChunkColumn.Remove(tmp);
+            }
         }
 
     }


### PR DESCRIPTION
- Issue confirmed in: 1.20.12 & 1.21.0-rc.1
- Mods: No mods in use
- Fix implemented in: latest 1.21.0-rc.1 (commit [1cca055](https://github.com/anegostudios/vsessentialsmod/commit/1cca05531b5c3a1325f31e38a182f63bb03ff135))

## Overview
### Issue 1
When a POI registers itself to the POI Registry, a `Vec2i` member field is updated and then used as a key to find the list of POIs for that a chunk. If the entry is not found, the same object is used as a key for the dictionary to store a new list.

The issue occurs when another POI in another chunk attempts to register. Because the dictionary key is the same `Vec2i` instance being used by the registry, updating the value also updates the keys in the dictionary. However, because the key hash is calculated when adding the key, and the object has changed, no collision occurs, and the same key is added again.

Making a copy of the `Vec2i` to use as key prevents the issue from occuring.

### Issue 2
When a POI is removed from the registry, and the list for the chunk the POI was in is empty, the empty list remains in the dictionary. This means the size of the dictionary will slowly grow in size over time, although the impact is likely limited.

Removing the list from the dictionary when the last element is removed prevents the issue from occuring.

## Reproduce
1. Set a breakpoint in [`POIRegistry.AddPOI`](https://github.com/anegostudios/vsessentialsmod/blob/master/Systems/POIRegistry.cs#L279), then place a block with POI behavior (such as a trough)
![poi_step1](https://github.com/user-attachments/assets/4f5901f6-5ec8-4772-a8a1-2e602e86be61)
2. A new key is added for the POI, and the POI added to the new list
![poi_step2](https://github.com/user-attachments/assets/0d853e93-15f4-4be8-9017-1107c642b221)
3. Place a trough in another chunk, when the value of `tmp` is modified, the value of the key also changes
![poi_step3](https://github.com/user-attachments/assets/8c210e01-52f8-4bf6-b4f9-a98cc91d3b45)
4. The new list is added to the dictionary using a duplicate key
![poi_step4](https://github.com/user-attachments/assets/f89ba465-9c92-4912-bf00-958271ca97c9)

## Result
After implementing the fix for issue 1, placing several troughs in different chunks results in the following:
![fix_1](https://github.com/user-attachments/assets/471637c5-fbfa-4da6-a7a2-4075642b6373)
All POIs are properly registered using their chunk coordinates as keys.