### PR TITLE
potential fix for hunger getting broken and not draining under certain conditions

### DIFF
--- a/Entity/Behavior/BehaviorHunger.cs
+++ b/Entity/Behavior/BehaviorHunger.cs
@@ -330,7 +330,7 @@ namespace Vintagestory.GameContent
 
             UpdateNutrientHealthBoost();
 
-            if (isondelay && !externalReduction) // external reduction is for normal hunger drain ticks
+            if (isondelay && !externalReduction) // external reduction is not for normal hunger drain ticks
             {
                 hungerCounter -= 10;
                 if (hungerCounter < 0f) hungerCounter = 0f;

--- a/Entity/Behavior/BehaviorHunger.cs
+++ b/Entity/Behavior/BehaviorHunger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
@@ -169,7 +169,7 @@ namespace Vintagestory.GameContent
         /// <param name="amount"></param>
         public virtual void ConsumeSaturation(float amount)
         {
-            ReduceSaturation(amount / 10f);
+            ReduceSaturation(amount / 10f); // not setting external reduction to false means it won't shorten the hungerCounter
         }
 
         public override void OnEntityReceiveSaturation(float saturation, EnumFoodCategory foodCat = EnumFoodCategory.Unknown, float saturationLossDelay = 10, float nutritionGainMultiplier = 1f)
@@ -214,6 +214,7 @@ namespace Vintagestory.GameContent
 
         public override void OnGameTick(float deltaTime)
         {
+            if (hungerCounter < 0) hungerCounter = 0f; // just in case is still somehow negative
             if (entity is EntityPlayer)
             {
                 EntityPlayer plr = (EntityPlayer)entity;
@@ -246,7 +247,7 @@ namespace Vintagestory.GameContent
 
                 satLossMultiplier *= entity.Stats.GetBlended("hungerrate");
 
-                ReduceSaturation(satLossMultiplier * multiplierPerGameSec);
+                ReduceSaturation(satLossMultiplier * multiplierPerGameSec, false);
 
                 hungerCounter = 0;
                 sprintCounter = 0;
@@ -271,7 +272,7 @@ namespace Vintagestory.GameContent
             }
         }
 
-        private bool ReduceSaturation(float satLossMultiplier)
+        private bool ReduceSaturation(float satLossMultiplier, bool externalReduction = true)
         {
             bool isondelay = false;
 
@@ -329,9 +330,10 @@ namespace Vintagestory.GameContent
 
             UpdateNutrientHealthBoost();
 
-            if (isondelay)
+            if (isondelay && !externalReduction) // external reduction is for normal hunger drain ticks
             {
                 hungerCounter -= 10;
+                if (hungerCounter < 0f) hungerCounter = 0f;
                 return true;
             }
 


### PR DESCRIPTION
potential fix for 
* https://github.com/anegostudios/VintageStory-Issues/issues/5815
* https://github.com/anegostudios/VintageStory-Issues/issues/5688
* https://github.com/anegostudios/VintageStory-Issues/issues/5519
* https://github.com/anegostudios/VintageStory-Issues/issues/5516
* https://github.com/anegostudios/VintageStory-Issues/issues/1033 maybe??

Note to clarify: This bug is not the delay that comes from eating a full meal. It is the bug that occurs when you take starvation damage and eat a single grain of flax and then never have to eat again for several in-game days on Wilderness Survival difficulty.
The bug occurs also when you take damage from any source and eat any food and so it can be disguised as normal gameplay operation, but the most egregious example outlined above shows how bad it can get and why it is game-breaking on any difficulty.

Break down of code and why it's an issue:
1. The OnGameTick adds `deltaTime` to the `hungerCounter` variable.  `hungerCounter += deltaTime;`  This occurs once roughly every second of in-game time. This means roughly one second of time (plus or minus a rounding error) is added to the hungerCounter. Once this counter exceeds 10f `if (hungerCounter > 10)` then several things happen, one of which is to make a method call to `ReduceSaturation(...)`.
2. When the player is injured the EntityBehaviorHealth class has its own OnGameTick method that will attempt to sacrifice some satiety for a small health boost. This amount is calculated and then sent to a method called `ConsumeSaturation()`. This method divides the saturation loss by 10 and passes it along to `ReduceSaturation()`
3. If the player has just eaten a sufficiently large meal, any of the follow has the potential to be quite large.
  a. `SaturationLossDelayFruit`
  b. `SaturationLossDelayVegetable`
  c. `SaturationLossDelayProtein`
  d. `SaturationLossDelayGrain`
  e. `SaturationLossDelayDairy`
4. Inside the EntityBehaviorHealth class, the `ApplyRegenAndHunger()` method references a few configuration values and has the potential to set the `healthRegenPerGameSecond` variable to a value that is quite low. Similarly, the amount of saturation passed to the `ConsumeSaturation` method has a potential to be quite low -- low enough that `amount / 10f` won't be large enough to deplete the saturation loss delays in a sufficient amount of time.
5. **Every time `ApplyRegenAndHunger()` calls `ConsumeSaturation`, if `isondelay` is true, then `hungerCounter` will be decremented by 10f.** This is the root of the problem and will plunge hungerCounter deep into the negatives because the only time it is set to zero is if it gets above 10f.

### Easy Solution:
Force `hungerCounter` to have a minimum of `0f`. I implemented this in both methods `OnGameTick` and `ReduceSaturation` of the `EntityBehaviorHunger` class to ensure that it never strays below 0 for any reasonable length of time.

### Difficult Solution:
Don't decrement the `hungerCounter` unless `ReduceSaturation` is called by the `OnGameTick` method of the `EntityBehaviorHunger` class. I propose adding a new parameter to `ReduceSaturation`. The name of this parameter is `externalReduction`. It has a default value of true. When it is given a value of `false`, then `hungerCounter` is a candidate for modification and having its value decremented by 10f.

**Why this works:**
When `ConsumeSaturation` calls `ReduceSaturation`, it will not set this new parameter. `ReduceSaturation` will skip over the bit of code that decrements `hungerCounter`. Only the `OnGameTick` method of `EntityBehaviorHunger` will set this new parameter to false so it will have sole control over the incrementing and decrementing of the `hungerCounter` variable.

I hope this fixes these long-standing issues and that you have a wonderful day.