### PR TITLE
Improvements to EntityBlockFalling.cs to limit the number of simultaneously falling objects

### DIFF
--- a/Entities/EntityBlockFalling.cs
+++ b/Entities/EntityBlockFalling.cs
@@ -206,7 +206,7 @@ namespace Vintagestory.GameContent
         // Positions that already have a pending request — prevents duplicates
         private static HashSet<BlockPos> pendingPositions = new HashSet<BlockPos>();
         // Maximum number of concurrently existing EntityBlockFalling instances
-        private static int maxFallingBlocks;
+        public static int maxFallingBlocks;
         private static ICoreServerAPI sapi;
         // Radius around a player within which entities are created (in blocks)
         private static int activeRange = 128;

--- a/Entities/EntityBlockFalling.cs
+++ b/Entities/EntityBlockFalling.cs
@@ -14,13 +14,20 @@ using Vintagestory.API.Server;
 
 namespace Vintagestory.GameContent
 {
+    /// <summary>
+    /// Client-side particle system for falling blocks.
+    /// Tracks active EntityBlockFalling instances and spawns dust and debris for them in an async thread.
+    /// </summary>
     public class FallingBlockParticlesModSystem : ModSystem
     {
+        // Dust particles — quad-shaped, slowly rise upward and dissipate
         public static SimpleParticleProperties dustParticles;
+        // Debris particles — cube-shaped, scatter sideways under gravity
         static SimpleParticleProperties bitsParticles;
 
         static FallingBlockParticlesModSystem()
         {
+            // Dust: large semi-transparent quads, drift upward, no gravity, self-propelled
             dustParticles = new SimpleParticleProperties(1, 3, ColorUtil.ToRgba(40, 220, 220, 220), new Vec3d(), new Vec3d(), new Vec3f(-0.25f, -0.25f, -0.25f), new Vec3f(0.25f, 0.25f, 0.25f), 1, 1, 0.3f, 0.3f, EnumParticleModel.Quad);
             dustParticles.AddQuantity = 5;
             dustParticles.MinVelocity.Set(-0.05f, -0.4f, -0.05f);
@@ -35,7 +42,7 @@ namespace Vintagestory.GameContent
             dustParticles.SelfPropelled = true;
             dustParticles.AddPos.Set(1.4, 1.4, 1.4);
 
-
+            // Debris: small cubes, scatter on impact, strong gravity
             bitsParticles = new SimpleParticleProperties(1, 3, ColorUtil.ToRgba(40, 220, 220, 220), new Vec3d(), new Vec3d(), new Vec3f(-0.25f, -0.25f, -0.25f), new Vec3f(0.25f, 0.25f, 0.25f), 1, 1, 0.1f, 0.3f, EnumParticleModel.Quad);
             bitsParticles.AddPos.Set(1.4, 1.4, 1.4);
             bitsParticles.AddQuantity = 20;
@@ -51,46 +58,68 @@ namespace Vintagestory.GameContent
         }
 
         ICoreClientAPI capi;
+
+        // Active falling blocks for which particles should be spawned
         HashSet<EntityBlockFalling> fallingBlocks = new HashSet<EntityBlockFalling>();
+
+        // Thread-safe queues for registration/removal between the game thread and particle thread
         ConcurrentQueue<EntityBlockFalling> toRegister = new ConcurrentQueue<EntityBlockFalling>();
         ConcurrentQueue<EntityBlockFalling> toRemove = new ConcurrentQueue<EntityBlockFalling>();
 
         public override bool ShouldLoad(EnumAppSide forSide)
         {
+            // Particles are only needed on the client
             return forSide == EnumAppSide.Client;
         }
 
         public override void StartClientSide(ICoreClientAPI api)
         {
             this.capi = api;
+            // Register the async spawner — it runs in a separate thread every frame
             api.Event.RegisterAsyncParticleSpawner(asyncParticleSpawn);
         }
 
+        /// <summary>
+        /// Add a block to the tracked list for particle spawning.
+        /// Called from EntityBlockFalling.Initialize on the client.
+        /// </summary>
         public void Register(EntityBlockFalling entity)
         {
             toRegister.Enqueue(entity);
         }
 
+        /// <summary>
+        /// Remove a block from the tracked list.
+        /// Called on despawn or after the block hits the ground.
+        /// </summary>
         public void Unregister(EntityBlockFalling entity)
         {
             toRemove.Enqueue(entity);
         }
 
+        /// <summary>
+        /// Number of active falling blocks currently being tracked for particle spawning.
+        /// </summary>
         public int ActiveFallingBlocks => fallingBlocks.Count;
 
 
+        /// <summary>
+        /// Async callback invoked every frame in the particle thread.
+        /// Spawns dust and debris for each tracked block.
+        /// </summary>
         private bool asyncParticleSpawn(float dt, IAsyncParticleManager manager)
         {
             int alive = manager.ParticlesAlive(EnumParticleModel.Quad);
 
-            // Reduce particle spawn the more falling blocks there are
-            // http://fooplot.com/#W3sidHlwZSI6MCwiZXEiOiIwLjk1Xih4LzUpIiwiY29sb3IiOiIjMDAwMDAwIn0seyJ0eXBlIjoxMDAwLCJ3aW5kb3ciOlsiMCIsIjIwMCIsIjAiLCIxIl19XQ--
+            // The more particles already in the air, the fewer new ones we spawn.
+            // Graph: http://fooplot.com/#W3sidHlwZSI6MCwiZXEiOiIwLjk1Xih4LzUpIiwiY29sb3IiOiIjMDAwMDAwIn0seyJ0eXBlIjoxMDAwLCJ3aW5kb3ciOlsiMCIsIjIwMCIsIjAiLCIxIl19XQ--
             float particlemul = Math.Max(0.05f, (float)Math.Pow(0.95f, alive / 200f));
 
             foreach (var bef in fallingBlocks)
             {
                 float dustAdd = 0f;
 
+                // On ground impact — one-time dust burst (only if the block is not underwater)
                 if (bef.nowImpacted)
                 {
                     var lblock = capi.World.BlockAccessor.GetBlock(bef.Pos.AsBlockPos, BlockLayersAccess.Fluid);
@@ -104,12 +133,14 @@ namespace Vintagestory.GameContent
 
                 if (bef.Block.Id != 0)
                 {
+                    // Sample color from the block's first drop for particle tinting
                     dustParticles.Color = bef.stackForParticleColor.Collectible.GetRandomColor(capi, bef.stackForParticleColor);
                     dustParticles.Color &= 0xffffff;
-                    dustParticles.Color |= (150 << 24);
+                    dustParticles.Color |= (150 << 24); // Semi-transparency
                     dustParticles.MinPos.Set(bef.Pos.X - 0.2 - 0.5, bef.Pos.Y, bef.Pos.Z - 0.2 - 0.5);
                     dustParticles.MinSize = 1f;
 
+                    // Dust emission intensity scales with fall speed
                     float veloMul = dustAdd / 20f;
                     dustParticles.AddPos.Y = bef.maxSpawnHeightForParticles;
                     dustParticles.MinVelocity.Set(-0.2f * veloMul, 1f * (float)bef.Pos.Motion.Y, -0.2f * veloMul);
@@ -120,8 +151,10 @@ namespace Vintagestory.GameContent
                     manager.Spawn(dustParticles);
                 }
 
+                // Debris is always spawned while the block is falling
                 bitsParticles.MinPos.Set(bef.Pos.X - 0.2 - 0.5, bef.Pos.Y - 0.5, bef.Pos.Z - 0.2 - 0.5);
 
+                // Debris downward velocity is proportional to the block's fall speed
                 bitsParticles.MinVelocity.Set(-2f, 30f * (float)bef.Pos.Motion.Y, -2f);
                 bitsParticles.AddVelocity.Set(4f, 0.2f * (float)bef.Pos.Motion.Y, 4f);
                 bitsParticles.MinQuantity = particlemul;
@@ -134,6 +167,8 @@ namespace Vintagestory.GameContent
                 capi.World.SpawnParticles(bitsParticles);
             }
 
+            // Process the register/remove queues at the end of the frame
+            // to avoid modifying the collection during iteration
             int cnt = toRegister.Count;
             while (cnt-- > 0)
             {
@@ -157,51 +192,293 @@ namespace Vintagestory.GameContent
     }
 
 
+    /// <summary>
+    /// Server-side spawn manager for falling blocks.
+    /// Limits the number of concurrently existing EntityBlockFalling instances,
+    /// queues spawn requests, and performs instant simulation for blocks outside player range.
+    /// </summary>
+    public class FallingSpawnManager : ModSystem
+    {
+        // Total number of loaded EntityBlockFalling instances on the server
+        private static int totalFallingBlocks = 0;
+        // Queue of spawn requests waiting for a free slot
+        private static Queue<SpawnRequest> requestQueue = new Queue<SpawnRequest>();
+        // Positions that already have a pending request — prevents duplicates
+        private static HashSet<BlockPos> pendingPositions = new HashSet<BlockPos>();
+        // Maximum number of concurrently existing EntityBlockFalling instances
+        private static int maxFallingBlocks;
+        private static ICoreServerAPI sapi;
+        // Radius around a player within which entities are created (in blocks)
+        private static int activeRange = 128;
+
+
+        public override bool ShouldLoad(EnumAppSide forSide)
+        {
+            return forSide == EnumAppSide.Server;
+        }
+
+        public override void StartServerSide(ICoreServerAPI api)
+        {
+            sapi = api;
+            maxFallingBlocks = 200; // TODO: move to server magic numbers config!
+
+            // Determine entity tracking radius from server settings
+            try
+            {
+                int trackingChunks = api.World.DefaultEntityTrackingRange;
+                activeRange = trackingChunks * GlobalConstants.ChunkSize;
+            }
+            catch { /* keep default of 128 */ }
+
+            api.Event.OnEntitySpawn += OnEntitySpawn;
+            api.Event.OnEntityLoaded += OnEntityLoaded;
+            api.Event.OnEntityDespawn += OnEntityDespawn;
+            // Spawn queue tick — every 32 ms
+            api.Event.RegisterGameTickListener(OnGameTick, 32);
+        }
+
+        // Counters: only track EntityBlockFalling, not living creatures
+        private void OnEntitySpawn(Entity entity)
+        {
+            if (!entity.IsCreature && entity is EntityBlockFalling) totalFallingBlocks++;
+        }
+
+        private void OnEntityLoaded(Entity entity)
+        {
+            if (!entity.IsCreature && entity is EntityBlockFalling) totalFallingBlocks++;
+        }
+
+        private void OnEntityDespawn(Entity entity, EntityDespawnData despawn)
+        {
+            if (!entity.IsCreature && entity is EntityBlockFalling) totalFallingBlocks--;
+        }
+
+        /// <summary>
+        /// Process the spawn queue each game tick.
+        /// Spawn as many entities as the limit allows.
+        /// </summary>
+        private void OnGameTick(float dt)
+        {
+            SpawnRequest request;
+            Block block;
+            Entity existing;
+
+            while (totalFallingBlocks < maxFallingBlocks && requestQueue.Count > 0)
+            {
+                request = requestQueue.Dequeue();
+                pendingPositions.Remove(request.InitialPos);
+
+                // Verify the block at the source position hasn't changed while the request was queued
+                block = sapi.World.BlockAccessor.GetBlock(request.InitialPos);
+                if (block == null || block.Id == 0 || block != request.Block)
+                    continue;
+
+                // If a falling entity already exists at this position — defer the spawn
+                existing = sapi.World.GetNearestEntity(
+                    request.InitialPos.ToVec3d().Add(0.5, 0.5, 0.5), 1, 1.5f,
+                    e => !e.IsCreature && e is EntityBlockFalling ebf && ebf.initialPos.Equals(request.InitialPos));
+
+                if (existing != null)
+                {
+                    request.RetryCount++;
+                    if (request.RetryCount >= 10)
+                    {
+                        // After 10 failed attempts — give up and drop items
+                        var drops = request.Block.GetDrops(sapi.World, request.InitialPos, null);
+                        EntityBlockFalling.SpawnDrops(sapi.World, request.InitialPos, drops, request.BlockEntity);
+                        continue;
+                    }
+                    // Return the request to the back of the queue for another attempt
+                    pendingPositions.Add(request.InitialPos);
+                    requestQueue.Enqueue(request);
+                    continue;
+                }
+
+                // Create the entity and apply position offset if specified
+                EntityBlockFalling entityBf = new EntityBlockFalling(
+                    request.Block, request.BlockEntity, request.InitialPos,
+                    request.FallSound, request.ImpactDamageMul,
+                    request.CanFallSideways, request.DustIntensity)
+                {
+                    DoRemoveBlock = request.DoRemoveBlock
+                };
+
+                sapi.World.SpawnEntity(entityBf);
+
+                if (request.PositionOffset != null && request.PositionOffset != Vec3d.Zero)
+                {
+                    entityBf.Pos.X += request.PositionOffset.X;
+                    entityBf.Pos.Y += request.PositionOffset.Y;
+                    entityBf.Pos.Z += request.PositionOffset.Z;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Requests a block to fall.
+        /// If a player is nearby — creates an entity (queued if at the limit).
+        /// If no players are nearby — performs instant simulation without an entity.
+        /// </summary>
+        public void RequestSpawn(Block block, BlockEntity be, BlockPos initialPos,
+                                 AssetLocation fallSound, float impactDamageMul,
+                                 bool canFallSideways, float dustIntensity,
+                                 bool doRemoveBlock = true, Vec3d positionOffset = null)
+        {
+            // Skip duplicates — this position already has a pending request
+            if (pendingPositions.Contains(initialPos))
+                return;
+
+            // Check whether at least one player is within activeRange
+            bool hasPlayerNearby = false;
+            Vec3d posVec = initialPos.ToVec3d();
+            EntityPlayer eplr;
+            foreach (IPlayer player in sapi.World.AllOnlinePlayers)
+            {
+                eplr = player.Entity;
+                if (eplr != null && eplr.Pos.InRangeOf(posVec, activeRange * activeRange, activeRange))
+                {
+                    hasPlayerNearby = true;
+                    break;
+                }
+            }
+
+            if (!hasPlayerNearby)
+            {
+                // No players nearby — no need to create an entity, simulate instantly
+                InstantFallSimulation(block, be, initialPos, fallSound, impactDamageMul,
+                                      canFallSideways, dustIntensity, doRemoveBlock, positionOffset);
+                return;
+            }
+
+            // Player is nearby — add to queue to create a full entity
+            pendingPositions.Add(initialPos);
+            requestQueue.Enqueue(new SpawnRequest
+            {
+                Block = block,
+                BlockEntity = be,
+                InitialPos = initialPos.Copy(),
+                FallSound = fallSound,
+                ImpactDamageMul = impactDamageMul,
+                CanFallSideways = canFallSideways,
+                DustIntensity = dustIntensity,
+                DoRemoveBlock = doRemoveBlock,
+                PositionOffset = positionOffset ?? Vec3d.Zero
+            });
+        }
+
+        /// <summary>
+        /// Thin wrapper: retrieves drops and delegates simulation to the static EntityBlockFalling method.
+        /// </summary>
+        private void InstantFallSimulation(Block block, BlockEntity be, BlockPos initialPos,
+                                           AssetLocation fallSound, float impactDamageMul,
+                                           bool canFallSideways, float dustIntensity,
+                                           bool doRemoveBlock, Vec3d positionOffset)
+        {
+            var drops = block.GetDrops(sapi.World, initialPos, null);
+            EntityBlockFalling.SimulateInstantFall(sapi.World, block, be, initialPos, drops, doRemoveBlock);
+        }
+
+        public override void Dispose()
+        {
+            // On mod unload, clear the queue and unsubscribe from events to avoid holding world object references
+            requestQueue.Clear();
+            pendingPositions.Clear();
+            totalFallingBlocks = 0;
+            if (sapi != null)
+            {
+                sapi.Event.OnEntitySpawn -= OnEntitySpawn;
+                sapi.Event.OnEntityLoaded -= OnEntityLoaded;
+                sapi.Event.OnEntityDespawn -= OnEntityDespawn;
+            }
+        }
+
+        /// <summary>
+        /// Data for a single spawn request held in the queue.
+        /// </summary>
+        private struct SpawnRequest
+        {
+            public Block Block;
+            public BlockEntity BlockEntity;
+            public BlockPos InitialPos;
+            public AssetLocation FallSound;
+            public float ImpactDamageMul;
+            public bool CanFallSideways;
+            public float DustIntensity;
+            public bool DoRemoveBlock;
+            public Vec3d PositionOffset;
+            public int RetryCount; // How many times this request has been returned to the queue due to a occupied position
+        }
+    }
+
 
     /// <summary>
-    /// Entity that represents a falling block like sand. When spawned it sets an air block at the initial
-    /// position. When it hits the ground it despawns and sets the original block back at that location.
+    /// Entity representing a falling block (sand, gravel, etc.).
+    /// Removes the block from its initial position on spawn,
+    /// and on landing either places the block at the final position or drops items.
     /// </summary>
     public class EntityBlockFalling : Entity
     {
+        // Packet ID used to synchronize the moment of impact with the client
         private const int packetIdMagicNumber = 1234;
-        static HashSet<long> fallingNow = new HashSet<long>();
+        // Set of EntityIds for blocks whose fall sound is currently playing
+        static public HashSet<long> fallingNow = new HashSet<long>();
 
+        // Order in which lateral directions are checked (randomized per EntityId for variety)
         private readonly List<int> fallDirections = new() { 0, 1, 2, 3 };
+        // Last lateral slide direction (prevents sliding back the way we came)
         private int lastFallDirection = 0;
+        // Height of the "hop" when stuck — increases with each failed attempt
         private int hopUpHeight = 1;
         private FallingBlockParticlesModSystem particleSys;
+        // Number of ticks since spawn — delay before physics begin
         private int ticksAlive;
+        // Remaining ticks before the entity dies after hitting the ground
         private int lingerTicks;
         private AssetLocation blockCode;
+        // Items that will drop if the block cannot be placed
         private ItemStack[] drops;
+        // Damage multiplier applied when entities are hit by the falling block
         private float impactDamageMul;
+        // Flag: fall has already been handled, no repeat processing needed
         private bool fallHandled;
         private byte[] lightHsv;
         private AssetLocation fallSound;
         private ILoadedSound sound;
+        // Delay before the sound starts — small random offset for naturalness
         private float soundStartDelay;
         private bool canFallSideways;
+        // Horizontal velocity during lateral sliding, decays over time
         private Vec3d fallMotion = new Vec3d();
+        // Accumulator for entity push damage (applied once per 0.2 s)
         private float pushaccum;
 
         internal float dustIntensity;
+        // Item stack used to determine particle color
         internal ItemStack stackForParticleColor;
+        // True at the moment of ground impact — triggers the particle burst
         internal bool nowImpacted;
 
-
+        // Flag: the initial block has already been removed from the world (needed for client sync)
         public bool InitialBlockRemoved;
+        // Block position before the fall began
         public BlockPos initialPos;
+        // Serialized BlockEntity state (if the block had one)
         public TreeAttribute blockEntityAttributes;
         public string blockEntityClass;
+        // Reference to the BlockEntity before it was removed (server-side only)
         public BlockEntity removedBlockentity;
-        // Additional config options
+        // If false — the block is not removed in Initialize (used for special effects)
         public bool DoRemoveBlock = true;
+        // Height above the block position at which particles are spawned
         public float maxSpawnHeightForParticles = 1.4f;
 
         public EntityBlockFalling() { }
+        // Very high density — block sinks in liquids instead of floating
         public override float MaterialDensity => 99999;
         public override byte[] LightHsv => lightHsv;
+
+        // The block never "freezes" (never enters sleep mode) — always ticks
+        public override bool AlwaysActive => true;
 
 
         public EntityBlockFalling(Block block, BlockEntity blockEntity, BlockPos initialPos, AssetLocation fallSound, float impactDamageMul, bool canFallSideways, float dustIntensity)
@@ -211,6 +488,7 @@ namespace Vintagestory.GameContent
             this.canFallSideways = canFallSideways;
             this.dustIntensity = dustIntensity;
 
+            // Store parameters in WatchedAttributes for client synchronization
             WatchedAttributes.SetBool("canFallSideways", canFallSideways);
             WatchedAttributes.SetFloat("dustIntensity", dustIntensity);
             if (fallSound != null)
@@ -221,8 +499,9 @@ namespace Vintagestory.GameContent
             this.Code = new AssetLocation("blockfalling");
             this.blockCode = block.Code;
             this.removedBlockentity = blockEntity;
-            this.initialPos = initialPos.Copy(); // Must have a Copy() here!
+            this.initialPos = initialPos.Copy(); // Must copy — the external object may change
 
+            // Center horizontally; slight downward offset removes z-fighting with the surface
             Pos.SetPos(initialPos);
             Pos.X += 0.5;
             Pos.Y -= 0.01;
@@ -232,6 +511,7 @@ namespace Vintagestory.GameContent
 
         public override void Initialize(EntityProperties properties, ICoreAPI api, long InChunkIndex3d)
         {
+            // Serialize the BlockEntity before the block is removed, to preserve its data
             if (removedBlockentity != null)
             {
                 this.blockEntityAttributes = new TreeAttribute();
@@ -239,12 +519,14 @@ namespace Vintagestory.GameContent
                 blockEntityClass = api.World.ClassRegistry.GetBlockEntityClass(removedBlockentity.GetType());
             }
 
-            SimulationRange = (int)(0.75f * GlobalConstants.DefaultSimulationRange);
+            // Large SimulationRange — entity ticks regardless of player distance
+            SimulationRange = 1500000;
+
             base.Initialize(properties, api, InChunkIndex3d);
 
             try
             {
-                // Need to capture this now before we remove the block and start to fall
+                // Cache drops before the block is removed — it won't be findable by position afterward
                 drops = Block.GetDrops(api.World, initialPos, null);
             }
             catch (Exception)
@@ -255,7 +537,7 @@ namespace Vintagestory.GameContent
 
             lightHsv = Block.GetLightHsv(World.BlockAccessor, initialPos);
 
-
+            // The first drop is used to determine dust particle color
             if (drops != null && drops.Length > 0)
             {
                 stackForParticleColor = drops[0];
@@ -265,6 +547,7 @@ namespace Vintagestory.GameContent
                 stackForParticleColor = new ItemStack(Block);
             }
 
+            // Start the fall sound only on the client and only if a slot is free (limit: 100)
             if (api.Side == EnumAppSide.Client && fallSound != null && fallingNow.Count < 100)
             {
                 fallingNow.Add(EntityId);
@@ -283,9 +566,9 @@ namespace Vintagestory.GameContent
                 soundStartDelay = 0.05f + (float)capi.World.Rand.NextDouble() / 3f;
             }
 
+            // Re-read from WatchedAttributes — the parameterized constructor is not called on the client
             canFallSideways = WatchedAttributes.GetBool("canFallSideways");
             dustIntensity = WatchedAttributes.GetFloat("dustIntensity");
-
 
             if (WatchedAttributes.HasAttribute("fallSound"))
             {
@@ -294,36 +577,32 @@ namespace Vintagestory.GameContent
 
             if (api.World.Side == EnumAppSide.Client)
             {
+                // Register with the particle system — dust will start spawning for us from this point
                 particleSys = api.ModLoader.GetModSystem<FallingBlockParticlesModSystem>();
                 particleSys.Register(this);
             }
 
+            // Shuffle lateral direction order — deterministic by EntityId so server and client match
             RandomizeFallingDirectionsOrder();
 
             if (DoRemoveBlock)
             {
-                // We have captured the BlockEntity and drops, we can now remove the initial block
-                // (but on a server we delay neighbour updates and notifying the client, deferred until later calls to UpdateBlock(true...)
+                // Now safe to remove the block from the world — drops and BlockEntity are already saved.
+                // On the server, client notification is deferred until UpdateBlock(true, ...) is called.
                 World.BlockAccessor.SetBlock(0, initialPos);
             }
         }
 
 
         /// <summary>
-        /// Delays behaviors from ticking to reduce flickering
+        /// Main entity tick. Updates sound, runs physics, checks for ground impact.
+        /// Physics are skipped for the first 2 ticks — gives time to render the block as an entity.
         /// </summary>
-        /// <param name="dt"></param>
         public override void OnGameTick(float dt)
         {
             World.FrameProfiler.Enter("entity-tick-unsstablefalling");
 
-            // (1 - 0.95^(x/100)) / 2
-            // http://fooplot.com/#W3sidHlwZSI6MCwiZXEiOiIoMS0wLjk1Xih4LzEwMCkpLzIiLCJjb2xvciI6IiMwMDAwMDAifSx7InR5cGUiOjEwMDAsIndpbmRvdyI6WyIwIiwiMzAwMCIsIjAiLCIxIl19XQ--
-            // if (physicsBh != null)
-            // {
-            //     physicsBh.clientPhysicsTickTimeThreshold = (float)((1 - Math.Pow(0.95, particleSys.ActiveFallingBlocks / 100.0)) / 4.0);
-            // }
-
+            // Sound start delay: Start() is called slightly after loading
             if (soundStartDelay > 0)
             {
                 soundStartDelay -= dt;
@@ -332,17 +611,19 @@ namespace Vintagestory.GameContent
                     sound.Start();
                 }
             }
+            // Keep the sound source position in sync with the block
             if (sound != null)
             {
                 sound.SetPosition((float)Pos.X, (float)Pos.Y, (float)Pos.Z);
             }
 
-
+            // lingerTicks: block has already landed, wait briefly before dying (for smoothness)
             if (lingerTicks > 0)
             {
                 lingerTicks--;
                 if (lingerTicks == 0)
                 {
+                    // Fade out the sound before destroying the entity
                     if (Api.Side == EnumAppSide.Client && sound != null)
                     {
                         sound.FadeOut(3f, (s) => { s.Dispose(); });
@@ -356,7 +637,9 @@ namespace Vintagestory.GameContent
             World.FrameProfiler.Mark("entity-tick-unsstablefalling-sound(etc)");
 
             ticksAlive++;
-            if (ticksAlive >= 2 || Api.World.Side == EnumAppSide.Client) // Seems like we have to do it instantly on the client, otherwise we miss the OnChunkRetesselated Event
+            // On the client, remove the block immediately (tick 1) or we miss the retessellation event.
+            // On the server, wait 2 ticks for stability.
+            if (ticksAlive >= 2 || Api.World.Side == EnumAppSide.Client)
             {
                 if (!InitialBlockRemoved)
                 {
@@ -364,6 +647,7 @@ namespace Vintagestory.GameContent
                     UpdateBlock(true, initialPos);
                 }
 
+                // Tick behaviors (including physics) only after the delay
                 foreach (EntityBehavior behavior in SidedProperties.Behaviors)
                 {
                     behavior.OnGameTick(dt);
@@ -371,6 +655,20 @@ namespace Vintagestory.GameContent
                 World.FrameProfiler.Mark("entity-tick-unsstablefalling-physics(etc)");
             }
 
+            // Periodically check whether all players have moved away from this block.
+            // If so, simulate instantly and destroy the entity —
+            // otherwise it would hang around until someone comes back.
+            if (Api.Side == EnumAppSide.Server && Api.World.ElapsedMilliseconds - lastPlayerCheckMs > PlayerCheckIntervalMs)
+            {
+                lastPlayerCheckMs = Api.World.ElapsedMilliseconds;
+                if (!IsPlayerNearby())
+                {
+                    FallNow();
+                    return;
+                }
+            }
+
+            // Push and damage nearby entities — once per 0.2 s
             pushaccum += dt;
             fallMotion.X *= 0.99f;
             fallMotion.Z *= 0.99f;
@@ -382,11 +680,21 @@ namespace Vintagestory.GameContent
                     Entity[] entities;
                     if (Api.Side == EnumAppSide.Server)
                     {
-                        entities = World.GetEntitiesAround(Pos.XYZ, 1.1f, 1.1f, (e) => !(e is EntityBlockFalling));
+                        // On the server, hit all non-falling creatures
+                        entities = World.GetEntitiesAround(this.Pos.XYZ, 1.1f, 1.1f, (e) => !(e is EntityBlockFalling));
+                    }
+                    else
+                    {
+                        // On the client, only players (for predictive push)
+                        entities = World.GetEntitiesAround(this.Pos.XYZ, 1.1f, 1.1f, (e) => (e.IsCreature && e is EntityPlayer));
+                    }
 
-                        bool didhit = false;
-                        foreach (var entity in entities)
+                    bool didhit = false;
+                    foreach (var entity in entities)
+                    {
+                        if (Api.Side == EnumAppSide.Server)
                         {
+                            // Crushing damage is proportional to vertical speed
                             bool nowhit = entity.ReceiveDamage(new DamageSource() { Source = EnumDamageSource.Block, Type = EnumDamageType.Crushing, SourceBlock = Block, SourcePos = Pos.XYZ }, 10 * (float)Math.Abs(Pos.Motion.Y) * impactDamageMul);
                             if (nowhit && !didhit)
                             {
@@ -394,27 +702,23 @@ namespace Vintagestory.GameContent
                                 Api.World.PlaySoundAt(this.Block.Sounds.Break, entity);
                             }
                         }
-                    }
-                    else
-                    {
-                        entities = World.GetEntitiesAround(Pos.XYZ, 1.1f, 1.1f, (e) => e is EntityPlayer);
-                    }
 
-                    for (int i = 0; i < entities.Length; i++)
-                    {
-                        entities[i].Pos.Motion.Add(fallMotion.X / 10f, 0, fallMotion.Z / 10f);
+                        // Push in the horizontal direction the block is moving
+                        entity.Pos.Motion.Add(fallMotion.X / 10f, 0, fallMotion.Z / 10f);
                     }
                 }
             }
 
-
             World.FrameProfiler.Mark("entity-tick-unsstablefalling-finalizemotion");
+
+            // Occasional neighbor update during fall — lets adjacent blocks react
             if (Api.Side == EnumAppSide.Server && !Collided && World.Rand.NextDouble() < 0.01)
             {
                 World.BlockAccessor.TriggerNeighbourBlockUpdate(Pos.AsBlockPos);
                 World.FrameProfiler.Mark("entity-tick-unsstablefalling-neighborstrigger");
             }
 
+            // Block has stopped vertically — time to handle landing
             if (CollidedVertically && Pos.Motion.Length() < 1E-3f)
             {
                 OnFallToGround(0);
@@ -424,41 +728,191 @@ namespace Vintagestory.GameContent
             World.FrameProfiler.Leave();
         }
 
+
+        // Timestamp of the last player proximity check (in game milliseconds)
+        private long lastPlayerCheckMs;
+        // Interval between player proximity checks
+        private const int PlayerCheckIntervalMs = 2000;
+
+        /// <summary>
+        /// Checks whether at least one online player is within activeRange of the block.
+        /// </summary>
+        private bool IsPlayerNearby()
+        {
+            int activeRange = (Api as ICoreServerAPI)?.World.DefaultEntityTrackingRange * GlobalConstants.ChunkSize ?? 128;
+            Vec3d pos = Pos.XYZ;
+            EntityPlayer eplr;
+
+            foreach (IPlayer player in Api.World.AllOnlinePlayers)
+            {
+                eplr = player.Entity;
+                if (eplr != null && eplr.Pos.InRangeOf(pos, activeRange * activeRange, activeRange))
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Forcefully completes the fall: instantly simulates the trajectory and destroys the entity.
+        /// Called when all players leave the area — no point keeping the entity alive.
+        /// </summary>
+        private void FallNow()
+        {
+            if (fallHandled)
+                return;
+            fallHandled = true;
+
+            SimulateInstantFall(Api.World, Block, removedBlockentity, initialPos, drops, false);
+            Die(EnumDespawnReason.Removed);
+        }
+
+        /// <summary>
+        /// Drops the block's items and BlockEntity contents at the center of the given position.
+        /// </summary>
+        public static void SpawnDrops(IWorldAccessor world, BlockPos pos, ItemStack[] drops, BlockEntity be)
+        {
+            var dpos = pos.ToVec3d().Add(0.5, 0.5, 0.5);
+            if (drops != null)
+                foreach (var drop in drops)
+                    world.SpawnItemEntity(drop, dpos);
+            // If the block had a container with inventory — drop its contents too
+            if (be is IBlockEntityContainer bec)
+                bec.DropContents(dpos);
+        }
+
+
+        /// <summary>
+        /// Instant fall simulation without creating an entity.
+        /// Finds the first free position below and places the block there,
+        /// or drops items if no valid position exists.
+        /// Used for blocks outside the player's visibility range.
+        /// </summary>
+        public static void SimulateInstantFall(
+            IWorldAccessor world,
+            Block block,
+            BlockEntity be,
+            BlockPos startPos,
+            ItemStack[] drops,
+            bool doRemoveBlock)
+        {
+            if (doRemoveBlock)
+            {
+                // Validity check: the block may have changed while the request was waiting
+                if (world.BlockAccessor.GetBlock(startPos) != block)
+                    return;
+                world.BlockAccessor.SetBlock(0, startPos);
+            }
+
+            BlockPos finalPos = startPos.Copy();
+
+            // Serialize the BlockEntity once for use in CanAcceptFallOnto / OnFallOnto
+            TreeAttribute beTree = null;
+            if (be != null)
+            {
+                beTree = new TreeAttribute();
+                be.ToTreeAttributes(beTree);
+            }
+
+            int worldHeight = world.BlockAccessor.MapSizeY;
+
+            // Descend while blocks below are passable (water, air, foliage, etc.)
+            for (int i = 0; i < worldHeight; i++)
+            {
+                BlockPos belowPos = finalPos.DownCopy();
+                Block belowBlock = world.BlockAccessor.GetMostSolidBlock(belowPos);
+
+                // Special block handler (e.g. loose soil, hopper, etc.)
+                if (belowBlock.CanAcceptFallOnto(world, belowPos, block, beTree))
+                {
+                    belowBlock.OnFallOnto(world, belowPos, block, beTree);
+                    return;
+                }
+
+                if (belowBlock.Replaceable >= 6000 || belowBlock.IsLiquid())
+                    finalPos = belowPos;  // Can pass through
+                else
+                    break;               // Hit a solid block
+            }
+
+            // Validate the final position: needs solid support below and free space above
+            Block targetBlock = world.BlockAccessor.GetBlock(finalPos);
+            Block supportBlock = world.BlockAccessor.GetMostSolidBlock(finalPos.DownCopy());
+
+            if (supportBlock.Replaceable < 6000 && !supportBlock.IsLiquid() &&
+                (targetBlock.IsLiquid() || targetBlock.Replaceable >= 6000))
+            {
+                // Conditions met — place the block at the final position
+                world.BlockAccessor.SetBlock(block.BlockId, finalPos);
+
+                // Restore BlockEntity state at the new position if it existed
+                if (be != null)
+                {
+                    BlockEntity newBe = world.BlockAccessor.GetBlockEntity(finalPos);
+                    if (newBe != null)
+                    {
+                        var tree = new TreeAttribute();
+                        be.ToTreeAttributes(tree);
+                        tree.SetInt("posx", finalPos.X);
+                        tree.SetInt("posy", finalPos.InternalY);
+                        tree.SetInt("posz", finalPos.Z);
+                        newBe.FromTreeAttributes(tree, world);
+                    }
+                }
+
+                return;
+            }
+
+            // Nowhere to land — drop items
+            SpawnDrops(world, finalPos, drops, be);
+        }
+
+
         public override void OnEntityDespawn(EntityDespawnData despawn)
         {
             base.OnEntityDespawn(despawn);
 
             if (Api.World.Side == EnumAppSide.Client)
             {
+                // Release the sound slot and unregister from the particle system
                 fallingNow.Remove(EntityId);
                 particleSys.Unregister(this);
             }
         }
 
 
+        /// <summary>
+        /// Updates the block in the world: when remove=true, marks it dirty (block already removed);
+        /// when remove=false, places the block at the new position and restores the BlockEntity.
+        /// </summary>
         private void UpdateBlock(bool remove, BlockPos pos)
         {
             if (remove)
             {
                 if (DoRemoveBlock)
                 {
+                    // Mark the chunk for redraw; enable entity rendering once retessellation completes
                     World.BlockAccessor.MarkBlockDirty(pos, () => OnChunkRetesselated(true));
-                } else
+                }
+                else
                 {
                     OnChunkRetesselated(true);
                 }
-            } else
+            }
+            else
             {
                 var lbock = World.BlockAccessor.GetBlock(pos, BlockLayersAccess.Fluid);
                 if (lbock.Id == 0 || Block.BlockMaterial != EnumBlockMaterial.Snow)
                 {
                     World.BlockAccessor.SetBlock(Block.BlockId, pos);
+                    // After redraw, disable entity rendering — the block is now static
                     World.BlockAccessor.MarkBlockDirty(pos, () => OnChunkRetesselated(false));
-                } else
+                }
+                else
                 {
                     OnChunkRetesselated(true);
                 }
 
+                // Restore BlockEntity data at the new position
                 if (blockEntityAttributes != null)
                 {
                     BlockEntity be = World.BlockAccessor.GetBlockEntity(pos);
@@ -478,13 +932,20 @@ namespace Vintagestory.GameContent
         }
 
 
+        /// <summary>
+        /// Enables or disables entity rendering depending on chunk tessellation state.
+        /// While the chunk is being redrawn — render as entity; afterward — hide.
+        /// </summary>
         private void OnChunkRetesselated(bool on)
         {
             EntityBlockFallingRenderer renderer = (Properties.Client.Renderer as EntityBlockFallingRenderer);
             if (renderer != null) renderer.DoRender = on;
         }
 
-        // based on entitId so should be same on server and client
+        /// <summary>
+        /// Shuffles the order of lateral directions for slide variety.
+        /// Deterministic by EntityId — server and client produce the same order.
+        /// </summary>
         private void RandomizeFallingDirectionsOrder()
         {
             for (int i = fallDirections.Count - 1; i > 0; i--)
@@ -497,6 +958,10 @@ namespace Vintagestory.GameContent
             lastFallDirection = fallDirections[3];
         }
 
+        /// <summary>
+        /// Called when the block touches the ground (vertical velocity ≈ 0).
+        /// Determines the final resting position.
+        /// </summary>
         public override void OnFallToGround(double motionY)
         {
             if (fallHandled) return;
@@ -522,20 +987,25 @@ namespace Vintagestory.GameContent
                 }
             }
 
+            // Try to slide sideways if the ground is uneven
             if (canFallSideways)
             {
+                Block nblock;
                 foreach (int i in fallDirections)
                 {
                     BlockFacing facing = BlockFacing.ALLFACES[i];
+                    // Don't slide back in the direction we just came from
                     if (facing == BlockFacing.NORTH && lastFallDirection == BlockFacing.SOUTH.Index) continue;
                     if (facing == BlockFacing.WEST && lastFallDirection == BlockFacing.EAST.Index) continue;
                     if (facing == BlockFacing.SOUTH && lastFallDirection == BlockFacing.NORTH.Index) continue;
                     if (facing == BlockFacing.EAST && lastFallDirection == BlockFacing.WEST.Index) continue;
 
 #pragma warning disable CS0618 // Type or member is obsolete - but it's correct here as we use pos.InternalY
-                    var nblock = World.BlockAccessor.GetMostSolidBlock(pos.X + facing.Normali.X, pos.InternalY + facing.Normali.Y, pos.Z + facing.Normali.Z);
+                    // Is the neighbor at the same level passable?
+                    nblock = World.BlockAccessor.GetMostSolidBlock(pos.X + facing.Normali.X, pos.InternalY + facing.Normali.Y, pos.Z + facing.Normali.Z);
                     if (nblock.Replaceable >= 6000)
                     {
+                        // Is the neighbor one level below also passable? — if so, slide diagonally down
                         nblock = World.BlockAccessor.GetMostSolidBlock(pos.X + facing.Normali.X, pos.InternalY + facing.Normali.Y - 1, pos.Z + facing.Normali.Z);
 #pragma warning restore CS0618
                         if (nblock.Replaceable >= 6000)
@@ -549,14 +1019,14 @@ namespace Vintagestory.GameContent
 
                             fallMotion.Set(facing.Normalf.X, 0, facing.Normalf.Z);
                             lastFallDirection = i;
-                            return;
+                            return; // Continue falling in the lateral direction
                         }
                     }
                 }
             }
 
+            // Impact moment — signal for the particle system
             nowImpacted = true;
-
 
             if (Api.Side == EnumAppSide.Server)
             {
@@ -568,18 +1038,20 @@ namespace Vintagestory.GameContent
                     {
                         if (block.Id != 0 && Block.BlockMaterial == EnumBlockMaterial.Snow)
                         {
+                            // Snow: increase snow layer level instead of replacing the block
                             UpdateSnowLayer(finalPos, block);
                             (Api as ICoreServerAPI).Network.BroadcastEntityPacket(EntityId, packetIdMagicNumber);
                         }
                         else if (block.IsReplacableBy(Block))
                         {
-                            // Here one more time because it might not get called in time
+                            // Remove the initial block if not already done (safety check)
                             if (!InitialBlockRemoved)
                             {
                                 InitialBlockRemoved = true;
                                 UpdateBlock(true, initialPos);
                             }
 
+                            // Place the block at the final position and notify clients
                             UpdateBlock(false, finalPos);
                             (Api as ICoreServerAPI).Network.BroadcastEntityPacket(EntityId, packetIdMagicNumber);
                         }
@@ -589,10 +1061,12 @@ namespace Vintagestory.GameContent
                 {
                     if (block.Replaceable >= 6000)
                     {
+                        // Final position is occupied by a soft block — drop items
                         DropItems(finalPos);
                     }
                     else
                     {
+                        // Stuck — hop upward slightly and try again
                         Pos.Y += hopUpHeight;
                         hopUpHeight += 1;
                         if (hopUpHeight > 3) hopUpHeight = 1;
@@ -600,6 +1074,7 @@ namespace Vintagestory.GameContent
                     }
                 }
 
+                // Damage all entities at the final position (crushing)
                 if (impactDamageMul > 0)
                 {
                     Entity[] entities = World.GetEntitiesInsideCuboid(finalPos, finalPos.AddCopy(1, 1, 1), (e) => !(e is EntityBlockFalling));
@@ -620,13 +1095,14 @@ namespace Vintagestory.GameContent
                 }
             }
 
+            // Let the entity linger a little longer so the client can play the impact animation
             lingerTicks = 50;
             fallHandled = true;
             hopUpHeight = 1;
         }
 
         /// <summary>
-        /// Simply update the snow level at the current position, no need to touch its BlockEntity (if there is one)
+        /// Increases the snow layer level on the target block.
         /// </summary>
         private void UpdateSnowLayer(BlockPos finalPos, Block block)
         {
@@ -637,6 +1113,9 @@ namespace Vintagestory.GameContent
             }
         }
 
+        /// <summary>
+        /// Receives a packet from the server: block has landed.
+        /// </summary>
         public override void OnReceivedServerPacket(int packetid, byte[] data)
         {
             base.OnReceivedServerPacket(packetid, data);
@@ -652,32 +1131,23 @@ namespace Vintagestory.GameContent
                 lingerTicks = 50;
                 fallHandled = true;
                 nowImpacted = true;
+                // Stop spawning particles — the block is now static
                 particleSys.Unregister(this);
             }
         }
 
 
-
+        /// <summary>
+        /// Drops the block's items and container contents (if any) at the given position.
+        /// </summary>
         private void DropItems(BlockPos pos)
         {
-            var dpos = pos.ToVec3d().Add(0.5, 0.5, 0.5);
-
-            if (drops != null)
-            {
-                for (int i = 0; i < drops.Length; i++)
-                {
-                    World.SpawnItemEntity(drops[i], dpos);
-                }
-            }
-
-            if (removedBlockentity is IBlockEntityContainer bec)
-            {
-                bec.DropContents(dpos);
-            }
+            SpawnDrops(World, pos, drops, removedBlockentity);
         }
 
+
         /// <summary>
-        /// The Block that is falling
+        /// The block that is falling. Looked up each time by blockCode.
         /// </summary>
         public Block Block
         {
@@ -690,6 +1160,7 @@ namespace Vintagestory.GameContent
 
             base.ToBytes(writer, forClient);
 
+            // Serialize the initial position and block code
             writer.Write(initialPos.X);
             writer.Write(initialPos.InternalY);
             writer.Write(initialPos.Z);
@@ -709,6 +1180,7 @@ namespace Vintagestory.GameContent
         {
             base.FromBytes(reader, forClient);
 
+            // Restore the initial position and block code
             initialPos = new BlockPos(reader.ReadInt32(), reader.ReadInt32(), reader.ReadInt32());
             blockCode = new AssetLocation(reader.ReadString());
 
@@ -732,15 +1204,16 @@ namespace Vintagestory.GameContent
             DoRemoveBlock = reader.ReadBoolean();
         }
 
+        // Falling blocks do not take damage
         public override bool ShouldReceiveDamage(DamageSource damageSource, float damage)
         {
             return false;
         }
 
+        // Whether the block can be interacted with
         public override bool IsInteractable
         {
             get { return false; }
         }
-
     }
 }


### PR DESCRIPTION
Greetings. One of the main issues with unstable block collapses and falls for many players (including me) was their erratic behavior. Specifically, the exponential growth of the number of falling block entities. This growth could lead to server TPS drops and player FPS drops. In some cases, on weaker computers, this could even cause the game to freeze.

What changes do I propose?

**1. FallingSpawnManager — Brand new server-side spawn queue**
Before: Every falling block immediately spawned a full EntityBlockFalling entity, with no cap. Thousands of blocks falling at once (e.g. large cave-ins) would create thousands of entities simultaneously, tanking server performance.
After: A dedicated manager limits concurrent falling block entities to 200. Excess requests wait in a queue and are processed tick-by-tick. If a block has been waiting too long with no valid position, items are dropped instead of hanging forever.

**2. Instant simulation for out-of-range blocks**
Before: Falling block entities were always created regardless of whether any player could actually see them, wasting CPU on physics simulation nobody observes.
After: If no player is within tracking range of the falling block, SimulateInstantFall() is called instead — the block teleports to its final resting position in one frame with zero entity overhead. Players near the area still get the full animated fall.

**3. AlwaysActive + large SimulationRange**
Before: EntityBlockFalling could enter sleep mode or stop ticking if the player moved away mid-fall, leaving blocks frozen in the air until someone came back.
After: AlwaysActive = true and an oversized SimulationRange ensure the entity always ticks to completion. Combined with the player proximity check, if all players leave mid-fall the entity finishes instantly via FallNow() rather than freezing.

**4. Player proximity watchdog (IsPlayerNearby / FallNow)**
Before: Once a full entity was spawned, it lived until it landed — even if every player logged out or teleported away.
After: Every 2 seconds the entity checks whether any player is still nearby. If not, it calls SimulateInstantFall() and self-destructs immediately, freeing the slot for the next queued block.

**Before:**
[Video 1](https://www.youtube.com/watch?v=e8HmqD1B0b8)

**After:**
Landslides of large quantities of sand. The video shows a limit of 1000 entities, but I ended up with 200. Ideally, you should factor this value into the server's magic numbers.
[Video 2](https://youtu.be/vc_C8FgsQZc)

Rock falls:
[Video 3](https://www.youtube.com/watch?v=Zw8-_DUQrgg)

Demonstration of instant simulation when the player moves away
[Video 4](https://youtu.be/1i3J2FW0W-Q)

Also, changes from here are required for work_ [PR](https://github.com/anegostudios/vssurvivalmod/pull/186)

P.S.: Smoke and dust particles are not visible because the _/time stop_ command is specified.
