### PR TITLE
Fix BehaviorContainer finding brightest slot incorrectly

### DIFF
--- a/Entity/Behavior/BehaviorContainer.cs
+++ b/Entity/Behavior/BehaviorContainer.cs
@@ -280,7 +280,7 @@ namespace Vintagestory.GameContent
 
             if (Inventory != null)
             {
-                var brightestSlot = Inventory.MaxBy(slot => slot.Empty ? 0 : slot.Itemstack.Collectible.LightHsv[2]);
+                var brightestSlot = Inventory.MaxBy(slot => slot.Empty ? 0 : slot.Itemstack.Collectible.GetLightHsv(entity.World.BlockAccessor, null, slot.Itemstack)[2]);
                 if (!brightestSlot.Empty)
                 {
                     entity.LightHsv = brightestSlot.Itemstack.Collectible.GetLightHsv(entity.World.BlockAccessor, null, brightestSlot.Itemstack);


### PR DESCRIPTION
The inventory's brightest light source is selected by the highest value in `Collectible.LightHsv`, but the itemstacks in the inventory may use a different variable light value by overriding `Collectible.GetLightHsv`, resulting in an incorrect light level being used. There are no current items in vanilla that are affected by this, but this was relevant for a mod implementing wearable items with variable light by overriding `Collectible.GetLightHsv`.

Simply sorting by `GetLightHsv` instead of `LightHsv` solves this issue.