### PR TITLE
Fix CompatibilityLib crash

### DIFF
--- a/IntermodTools.cs
+++ b/IntermodTools.cs
@@ -46,6 +46,16 @@ namespace Vintagestory.ServerMods
                     // Remap the original asset path to the new path
                     var origPath = new AssetLocation(mod.Info.ModID, asset.Location.Path.Remove(0, prefix.Length));
 
+                    // Skip invalid asset categories instead of crashing the utility
+                    if (origPath.Category == null)
+                    {
+                        api.World.Logger.Error("Compatibility lib: unknown asset category {0}", origPath.FirstPathPart());
+                        continue;
+                    }
+                    
+                    // Some asset categories are not loaded on the client or server. In those cases, we don't have to patch anything anyway
+                    if ((origPath.Category.SideType & api.Side) == 0) continue;
+
                     if (api.Assets.AllAssets.ContainsKey(origPath))
                     {
                         quantityReplaced++;
@@ -54,10 +64,7 @@ namespace Vintagestory.ServerMods
                     {
                         quantityAdded++;
                     }
-
-                    // Some asset categories are not loaded on the client or server. In those cases, we don't have to patch anything anyway
-                    if ((origPath.Category.SideType & api.Side) == 0) continue;
-
+                    
                     api.Assets.Add(origPath, asset);
                 }
             }


### PR DESCRIPTION
If the asset category does not exist, CompatibilityLib crashes while checking origPath.Category.Side.

A common cause is that modders accidentally specify the modid twice, for example:
`assets/MODID/compatibility/othermodid/MODID/catname/path/to/asset`  (wrong)
`assets/MODID/compatibility/othermodid/catname/path/to/asset` (valid)
In the wrong example, MODID is treated as an asset category, which results in an null category.

This change adds an explicit check for a missing origPath.Category and reports an error instead of crashing.
Additionally, the skip logic for sided assets has been moved earlier so that skipped assets are no longer included in the counter.