### PR TITLE
Taking out the trash in BlockPatch

### DIFF
--- a/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/BlockPatch.cs
+++ b/Systems/WorldGen/Standard/ChunkGen/8.GenVegetationAndPatches/BlockPatch.cs
@@ -237,9 +237,6 @@ namespace Vintagestory.ServerMods.NoObf
             Block[] blocks = getBlocks(firstBlockId);
             if (blocks.Length == 0) return;
 
-            ModStdWorldGen modSys = null;
-            if (blockAccessor is IWorldGenBlockAccessor wgba) modSys = wgba.WorldgenWorldAccessor.Api.ModLoader.GetModSystem<GenVegetationAndPatches>();
-
             while (quantity-- > 0)
             {
                 if (quantity < 1 && rnd.NextFloat() > quantity) break;


### PR DESCRIPTION
## Summary

I just removed two lines of code that were causing load but weren't used anywhere.

[Also sent to Stratum](https://github.com/StratumServer/Stratum/pull/120)

## Performance numbers

Tested on the generation of 10200 chunk columns:
- method execution time: reduced from 5109 ms to 3595 ms;
- GC memory allocations: reduced from 671 MB to 430 MB.

**Before**
<img width="676" height="395" alt="blockpatch before trace" src="https://github.com/user-attachments/assets/3cf76e93-8c19-429d-b95e-836eb06a11d0" />
<img width="1625" height="350" alt="blockpatch before mem" src="https://github.com/user-attachments/assets/abe62ec7-d905-46eb-aa4e-d9161662070a" />


**After**
<img width="668" height="432" alt="blockpatch after trace" src="https://github.com/user-attachments/assets/d074365b-167e-4176-84f6-e8857d7fe206" />
<img width="1799" height="436" alt="blockpatch after mem" src="https://github.com/user-attachments/assets/3d8b0472-c90d-4f9c-8f73-9fd8f8d5162d" />
