### PR TITLE
Optimization of genBlockColumn and WeightsAt

### DIFF
--- a/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
+++ b/Systems/WorldGen/Standard/ChunkGen/2.GenRockStrata/GenRockStrata.cs
@@ -138,6 +138,7 @@ namespace Vintagestory.ServerMods
         #region
         float[] rockGroupMaxThickness = new float[4];
         int[] rockGroupCurrentThickness = new int[4];
+        float[] indicesBuf; // reused buffer
 
         IMapChunk mapChunk;
         ushort[] heightMap;
@@ -194,15 +195,21 @@ namespace Vintagestory.ServerMods
             rockGroupMaxThickness[0] = rockGroupMaxThickness[1] = rockGroupMaxThickness[2] = rockGroupMaxThickness[3] = 0;
             rockGroupCurrentThickness[0] = rockGroupCurrentThickness[1] = rockGroupCurrentThickness[2] = rockGroupCurrentThickness[3] = 0;
 
-            float[] indices = new float[provinces.Variants.Length];
+            // use a buffer to reduce allocations
+            // Just in case, check the dimensions           
+            if (indicesBuf == null || indicesBuf.Length != provinces.Variants.Length)
+                indicesBuf = new float[provinces.Variants.Length];
+
             map.WeightsAt(
                 chunkInRegionX + lx * lerpMapInv,
                 chunkInRegionZ + lz * lerpMapInv,
-                indices
+                indicesBuf
             );
-            for (int i = 0; i < indices.Length; i++)
+
+            for (int i = 0; i < indicesBuf.Length; i++)
             {
-                float w = indices[i];
+                float w = indicesBuf[i];
+                // Stratum end
                 if (w == 0) continue;
 
                 GeologicProvinceRockStrata[] localstrata = provinces.Variants[i].RockStrataIndexed;

--- a/Systems/WorldGen/Standard/Datastructures/LerpedWeightedIndex2DMap.cs
+++ b/Systems/WorldGen/Standard/Datastructures/LerpedWeightedIndex2DMap.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -98,10 +98,8 @@ namespace Vintagestory.ServerMods
         /// </summary>
         public float[] WeightsAt(float x, float z, float[] output)
         {
-            for (int i = 0; i < output.Length; i++)
-            {
-                output[i] = 0;
-            }
+            // Quickly clear the array and reuse variables
+            Array.Clear(output, 0, output.Length); 
 
             int posXLeft = (int)Math.Floor(x - 0.5f) + topleftPadding;
             int posXRight = posXLeft + 1;
@@ -112,17 +110,21 @@ namespace Vintagestory.ServerMods
             float fx = x - (posXLeft - topleftPadding + 0.5f);
             float fz = z - (posZLeft - topleftPadding + 0.5f);
 
+            int num1 = posZLeft * sizeX;
+
             HalfBiLerp(   // Top
-                groups[posZLeft * sizeX + posXLeft],
-                groups[posZLeft * sizeX + posXRight],
+                groups[num1 + posXLeft],
+                groups[num1 + posXRight],
                 fx,
                 output,
                 (1 - fz)
             );
 
+            int num2 = posZRight * sizeX;
+
             HalfBiLerp(    // Bottom
-                groups[posZRight * sizeX + posXLeft],
-                groups[posZRight * sizeX + posXRight],
+                groups[num2 + posXLeft],
+                groups[num2 + posXRight],
                 fx,
                 output,
                 fz


### PR DESCRIPTION
## Summary

Changes for **genBlockColumn**:
- Buffer for float[] data used.

Changes for **WeightsAt**:
- Loop replaced with immediate clearing of the output array, variables reused.


## Performance numbers

Tested on the generation of 10200 chunk columns:
- genBlockColumn method execution time: reduced from 16152 ms to 14678 ms;
- genBlockColumn GC memory allocations: reduced from 639 MB to 90 MB;
- WeightsAt method execution time: reduced from 600 ms to 10 ms;

<details>
  <summary>BEFORE spoiler</summary>
<img width="731" height="293" alt="rockstrata before trace" src="https://github.com/user-attachments/assets/e5f78629-b065-417e-9a65-fad57720ad34" />
<img width="1747" height="356" alt="rockstrata before mem" src="https://github.com/user-attachments/assets/a325fb4b-4fc4-4732-847e-5e8e1b30dcf2" />
<img width="823" height="206" alt="weightsat before trace" src="https://github.com/user-attachments/assets/3fee6435-213c-4223-b12c-3bae65d16a29" />
<img width="1920" height="1017" alt="2026-07-11_15-59-23" src="https://github.com/user-attachments/assets/efcb22ce-f0ca-4750-889e-1bd58504e366" />
<img width="1920" height="1017" alt="2026-07-11_16-15-07" src="https://github.com/user-attachments/assets/af0de873-160d-4e46-b844-81cbbb02b2fd" />
</details>


<details>
  <summary>AFTER spoiler</summary>
<img width="847" height="358" alt="rockstrata after trace" src="https://github.com/user-attachments/assets/2b4987c0-8763-49c0-a7df-9a9215794e52" />
<img width="1729" height="459" alt="rockstrata after mem" src="https://github.com/user-attachments/assets/172f39cb-bc32-41b3-a27e-28a2633568b2" />
<img width="833" height="223" alt="weightsat after trace" src="https://github.com/user-attachments/assets/c5a8b942-1e3e-4c2b-8ac4-ca5e3fb77d41" />
<img width="1920" height="1017" alt="stratum rocks 1" src="https://github.com/user-attachments/assets/7b6a602b-dcb0-4d1c-b876-e080688effbc" />
<img width="1920" height="1017" alt="stratum rocks 2" src="https://github.com/user-attachments/assets/793e2303-6ec9-4ffe-aff6-08d809e77b46" />
</details>
