### PR TITLE
Guard against a null chunk in GenPonds' pond search

### DIFF
--- a/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
+++ b/Systems/WorldGen/Standard/ChunkGen/7.GenPonds/GenPonds.cs
@@ -283,6 +283,7 @@ namespace Vintagestory.ServerMods
                 {
                     chunk = (IServerChunk)blockAccessor.GetChunk(curChunkX, pondYPos / chunksize, curChunkZ);
                     if (chunk == null) chunk = api.WorldManager.GetChunk(curChunkX, pondYPos / chunksize, curChunkZ);
+                    if (chunk == null) return;
                     chunk.Unpack();
 
                     if (ly == 0)


### PR DESCRIPTION
`GenPonds.genPond` looks up the chunk it is about to write into, falls back to a second lookup when the first misses, and then calls `Unpack()` on the result without checking it:

```csharp
chunk = (IServerChunk)blockAccessor.GetChunk(curChunkX, pondYPos / chunksize, curChunkZ);
if (chunk == null) chunk = api.WorldManager.GetChunk(curChunkX, pondYPos / chunksize, curChunkZ);
chunk.Unpack();          // NRE if the fallback missed too
```

The fallback can return null, so this throws a `NullReferenceException` when a neighbouring column is absent or being unloaded while the pond search walks into it. It is reachable with `MaxWorldgenThreads` above 1, where columns come and go around the one currently generating.

The sibling lookup six lines below already handles the same situation by bailing out:

```csharp
chunkOneBlockBelow = ((IServerChunk)blockAccessor.GetChunk(curChunkX, (pondYPos - 1) / chunksize, curChunkZ));
if (chunkOneBlockBelow == null) return;
chunkOneBlockBelow.Unpack();
```

This adds the same guard to the first lookup, so the two are consistent. One line, and it only changes behaviour on a path that currently throws.

Found while running world generation with several worldgen threads. Related, though a separate bug: anegostudios/VintageStory-Issues#9871.
